### PR TITLE
fix(message): 修正活動更新後的確認訊息與狀態

### DIFF
--- a/src/index.integration.test.ts
+++ b/src/index.integration.test.ts
@@ -806,8 +806,8 @@ describe('handleFileMessage', () => {
       const replyArgs = mockReplyMessage.mock.calls[0];
       const templateMessage = replyArgs[1];
       expect(templateMessage.type).toBe('template');
-      expect(templateMessage.template.text).toContain(`地點：${changes.location}`);
-      expect(templateMessage.template.text).toContain(`備註：${changes.description}`);
+      expect(templateMessage.template.text).not.toContain(`地點：`);
+      expect(templateMessage.template.text).not.toContain(`備註：`);
     });
 
     it('handleTextMessage - 應該在對話狀態中透過輸入「取消」來清除狀態', async () => {


### PR DESCRIPTION
- 修正因地點或備註過長，導致更新活動後的回覆訊息超過 LINE 平台字元限制而發送失敗 (400 Bad Request) 的問題。調整確認卡片，僅保留標題與時間。
- 同步更新對應的整合測試，以符合新的訊息內容。
- 修正活動修改成功後，對話狀態 (awaiting_modification_details) 在群組/聊天室中未被正確清除的問題。